### PR TITLE
fix: Disable deprecated Flow Control & use `async` / `await`

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,7 +19,7 @@ test_script:
   - node --version
   - npm --version
   # run tests
-  - npm run test-win
+  - npm run test
 
 build:
   off

--- a/conf.js
+++ b/conf.js
@@ -8,6 +8,14 @@ exports.config = {
   // Spec files with our tests.
   specs: ['*_spec.js'],
 
+  // Required since we're using `async` / `await`:
+  // "Because async/await uses native promises, it will make the Control Flow
+  // unreliable"
+  // Control Flow is also deprecated
+  // see: https://www.protractortest.org/#/control-flow
+  // see: https://github.com/SeleniumHQ/selenium/issues/2969
+  SELENIUM_PROMISE_MANAGER: false,
+
   // Options for the webdriver instance to use in tests.
   capabilities: {
     browserName: 'chrome',

--- a/package-lock.json
+++ b/package-lock.json
@@ -320,7 +320,7 @@
         },
         "globby": {
           "version": "9.2.0",
-          "resolved": "http://registry.npmjs.org/globby/-/globby-9.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-9.2.0.tgz",
           "integrity": "sha512-ollPHROa5mcxDEkwg6bPt3QbEf4pDQSNtd6JPL1YvOvAo/7/0VAm9TccUeoTmarjPw4pfUthSCqcyfNB1I3ZSg==",
           "dev": true,
           "requires": {
@@ -343,9 +343,9 @@
       }
     },
     "@percy/protractor": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@percy/protractor/-/protractor-1.0.3.tgz",
-      "integrity": "sha512-GMNx5t4q1bI7K6Mwj/KagTJ5/Gmi2uC+TSOMTTX4LLVmreyJQRTWrZNzsWsSgXp/jqITTxzUcHlI148r7y407g==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@percy/protractor/-/protractor-1.0.4.tgz",
+      "integrity": "sha512-+bmBXmcQDt4J4Ny1bEh0U8b0X++FMdQVmV423FkZX2X69VNatdV4TqLhvtuilWL/3ZawkgdG/A1hUYn3c9NrTw==",
       "dev": true,
       "requires": {
         "@percy/agent": "~0"
@@ -427,9 +427,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "12.0.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.0.4.tgz",
-      "integrity": "sha512-j8YL2C0fXq7IONwl/Ud5Kt0PeXw22zGERt+HSSnwbKOJVsAGkEz3sFCYwaF9IOuoG1HOtE0vKCj6sXF7Q0+Vaw==",
+      "version": "12.0.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.0.5.tgz",
+      "integrity": "sha512-CFLSALoE+93+Hcb5pFjp0J1uMrrbLRe+L1+gFwerJ776R3TACSF0kTVRQ7AvRa7aFx70nqYHAc7wQPlt9kY2Mg==",
       "dev": true
     },
     "@types/puppeteer": {
@@ -525,7 +525,7 @@
     },
     "ansi-escapes": {
       "version": "3.2.0",
-      "resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
       "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
       "dev": true
     },
@@ -666,7 +666,7 @@
     },
     "axios": {
       "version": "0.18.1",
-      "resolved": "http://registry.npmjs.org/axios/-/axios-0.18.1.tgz",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.1.tgz",
       "integrity": "sha512-0BfJq4NSfQXd+SkFdrvFbG7addhYSBA2mQwISr46pD6E5iqkWg02RAs8vyTT/j0RTnoYmeXauBuSv1qKwR179g==",
       "dev": true,
       "requires": {
@@ -1106,7 +1106,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
@@ -1730,7 +1730,7 @@
     },
     "finalhandler": {
       "version": "1.1.2",
-      "resolved": "http://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
       "integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
       "dev": true,
       "requires": {
@@ -2012,7 +2012,7 @@
     },
     "http-errors": {
       "version": "1.7.2",
-      "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
       "integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
       "dev": true,
       "requires": {
@@ -2505,7 +2505,7 @@
     },
     "media-typer": {
       "version": "0.3.0",
-      "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
       "dev": true
     },
@@ -4045,7 +4045,7 @@
       "dependencies": {
         "async": {
           "version": "1.0.0",
-          "resolved": "http://registry.npmjs.org/async/-/async-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
           "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k=",
           "dev": true
         }

--- a/package.json
+++ b/package.json
@@ -3,11 +3,9 @@
   "scripts": {
     "webdriver-update": "webdriver-manager update --gecko false --standalone false",
     "install": "npm run webdriver-update || npm run webdriver-update",
-    "test": "percy exec -- protractor conf.js",
-    "test-win": "percy exec -- protractor.cmd conf.js"
+    "test": "percy exec -- protractor conf.js"
   },
   "devDependencies": {
-    "@percy/agent": "^0.5.2",
     "@percy/protractor": "^1.0.3",
     "http-server": "^0.11.1",
     "protractor": "^5.4.2"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "test": "percy exec -- protractor conf.js"
   },
   "devDependencies": {
-    "@percy/protractor": "^1.0.3",
+    "@percy/protractor": "^1.0.4",
     "http-server": "^0.11.1",
     "protractor": "^5.4.2"
   },

--- a/todomvc_spec.js
+++ b/todomvc_spec.js
@@ -17,40 +17,39 @@ describe('TodoMVC', function() {
     server.close()
   })
 
-  afterEach(function() {
+  afterEach(async function() {
     // Clear local storage between tests so that we always start with a clean slate.
-    browser.executeScript('window.localStorage.clear()')
+    await browser.executeScript('window.localStorage.clear()')
   })
 
-  it('Loads the app', function() {
-    browser.get(TEST_URL)
-    expect(element(by.css('section.todoapp')).isPresent()).toBe(true)
-    percySnapshot("Home page")
+  it('Loads the app', async function() {
+    await browser.get(TEST_URL)
+    expect(await element(by.css('section.todoapp')).isPresent()).toBe(true)
+    await percySnapshot("Home page")
   })
 
-  it('Accepts a new todo', function() {
-    browser.get(TEST_URL)
-    element(by.css('.new-todo')).sendKeys('New fancy todo', protractor.Key.ENTER)
+  it('Accepts a new todo', async function() {
+    await browser.get(TEST_URL)
+    await element(by.css('.new-todo')).sendKeys('New fancy todo', protractor.Key.ENTER)
 
-    element.all(by.css('.todo-list li')).then(function(todos) {
-      expect(todos.length).toBe(1)
-    })
+    const todos = await element.all(by.css('.todo-list li'))
+    expect(todos.length).toBe(1)
 
-    percySnapshot("New todo", { widths: [768, 992, 1200] })
+    await percySnapshot("New todo", { widths: [768, 992, 1200] })
   })
 
-  it('Lets you check off a a todo', function() {
-    browser.get(TEST_URL)
-    element(by.css('.new-todo')).sendKeys('A thing to accomplish', protractor.Key.ENTER)
+  it('Lets you check off a a todo', async function() {
+    await browser.get(TEST_URL)
+    await element(by.css('.new-todo')).sendKeys('A thing to accomplish', protractor.Key.ENTER)
 
-    let itemsLeftText = element(by.css('.todo-count')).getText()
-    expect(itemsLeftText).toBe('1 item left')
+    let itemsLeftText = await element(by.css('.todo-count')).getText()
+    await expect(itemsLeftText).toBe('1 item left')
 
-    element(by.css('input.toggle')).click()
+    await element(by.css('input.toggle')).click()
 
-    itemsLeftText = element(by.css('.todo-count')).getText()
-    expect(itemsLeftText).toBe('0 items left')
+    itemsLeftText = await element(by.css('.todo-count')).getText()
+    await expect(itemsLeftText).toBe('0 items left')
 
-    percySnapshot("Checked-off todo", { widths: [300] })
+    await percySnapshot("Checked-off todo", { widths: [300] })
   })
 })


### PR DESCRIPTION
## What is this?

Turns out Protractor uses this thing called "Webdriver Flow Control" to handle test command execution. It relies on promises to know when to go to the next step in the tests. 

Flow Control is deprecated (see: https://github.com/SeleniumHQ/selenium/issues/2969) and will be removed. This is because packages / tests that use `async` / `await` don't _quite_ work with Flow Control due to the difference in promise interfaces (I'm assuming native promises vs polyfills). 

Protractor recommends using `async` / `await` now (https://www.protractortest.org/#/control-flow): 

> In the future, the control flow is being removed (see SeleniumHQ's github issue for details). To disable the control flow in your tests, you can use the SELENIUM_PROMISE_MANAGER: false config option.

> Instead of the control flow, you can synchronize your commands with promise chaining or the upcoming ES7 feature async/await. See /spec/ts/ for examples of tests with the control flow disabled.

>Because async/await uses native promises, it will make the Control Flow unreliable


This PR also removes the windows test commands since they're not needed anymore. 👍 